### PR TITLE
Add a new option to LoadingConfiguration to disable loaded schema cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ target
 build
 .gradle
 out
-
+.nb-gradle*

--- a/src/main/java/com/github/fge/jsonschema/load/configuration/LoadingConfiguration.java
+++ b/src/main/java/com/github/fge/jsonschema/load/configuration/LoadingConfiguration.java
@@ -47,6 +47,7 @@ import java.util.Map;
  * <ul>
  *     <li>what schemas should be preloaded;</li>
  *     <li>what URI schemes should be supported;</li>
+ *     <li>if we want to cache loaded schemas.</li>
  *     <li>set a default namespace for loading schemas from URIs;</li>
  *     <li>add redirections from one schema URI to another;</li>
  *     <li>what dereferencing mode should be used.</li>
@@ -73,6 +74,11 @@ public final class LoadingConfiguration
     final Map<String, URIDownloader> downloaders;
 
     final URITransformer transformer;
+    
+    /**
+     * If we have to cache loaded schemas, note that this do not affect preloadedSchema that are always cached
+     */
+    final boolean enableCache;
 
     /**
      * Dereferencing mode
@@ -143,6 +149,7 @@ public final class LoadingConfiguration
         preloadedSchemas = ImmutableMap.copyOf(builder.preloadedSchemas);
         parserFeatures = EnumSet.copyOf(builder.parserFeatures);
         objectReader = constructObjectReader();
+        enableCache = builder.enableCache;
     }
 
     /**
@@ -231,6 +238,16 @@ public final class LoadingConfiguration
     public ObjectReader getObjectReader()
     {
         return objectReader;
+    }
+    
+    /**
+     * Return if we want to cache loaded schema or not
+     * note that this do not affect preloadedSchema that are always cached
+     * 
+     * @return if the cache has to be enabled
+     */
+    public boolean getEnableCache() {
+        return enableCache;
     }
 
     /**

--- a/src/main/java/com/github/fge/jsonschema/load/configuration/LoadingConfigurationBuilder.java
+++ b/src/main/java/com/github/fge/jsonschema/load/configuration/LoadingConfigurationBuilder.java
@@ -76,6 +76,11 @@ public final class LoadingConfigurationBuilder
         = new URIDownloadersRegistry();
 
     URITransformer transformer;
+  
+    /**
+     * Loaded schemas are cached by default
+     */
+    boolean enableCache = true;
 
     /**
      * Dereferencing mode
@@ -130,8 +135,19 @@ public final class LoadingConfigurationBuilder
         dereferencing = cfg.dereferencing;
         preloadedSchemas = Maps.newHashMap(cfg.preloadedSchemas);
         parserFeatures = EnumSet.copyOf(cfg.parserFeatures);
+        enableCache = cfg.enableCache;
     }
 
+    /**
+     * 
+     * @param enableCache if loaded schemas have to be cached
+     * @return this
+     */
+    public LoadingConfigurationBuilder setEnableCache(boolean enableCache) {
+        this.enableCache = enableCache;
+        return this;
+    }
+    
     /**
      * Add a new URI downloader
      *

--- a/src/test/java/com/github/fge/jsonschema/load/SchemaLoaderTest.java
+++ b/src/test/java/com/github/fge/jsonschema/load/SchemaLoaderTest.java
@@ -131,6 +131,12 @@ public final class SchemaLoaderTest
 
         registry.get(uri);
         verify(mock, never()).fetch(uri);
+
+        //even if cache is disabled
+        final LoadingConfiguration cfgNoCache = cfg.thaw().setEnableCache(false).freeze();
+        final SchemaLoader registryNoCache = new SchemaLoader(cfgNoCache);
+        registry.get(uri);
+        verify(mock, never()).fetch(uri);        
     }
 
     @Test
@@ -156,4 +162,29 @@ public final class SchemaLoaderTest
         loader.get(uri);
         verify(downloader, times(1)).fetch(uri);
     }
+    
+    @Test
+    public void schemasCacheCanBeDisabled()
+        throws ProcessingException, IOException
+    {
+        final URI uri = URI.create("foo:/baz#");
+        final URIDownloader downloader = spy(new URIDownloader()
+        {
+            @Override
+            public InputStream fetch(final URI source)
+                throws IOException
+            {
+                return new ByteArrayInputStream(BYTES);
+            }
+        });
+
+        final LoadingConfiguration cfg = LoadingConfiguration.newBuilder()
+            .addScheme("foo", downloader).setEnableCache(false).freeze();
+        final SchemaLoader loader = new SchemaLoader(cfg);
+
+        loader.get(uri);
+        loader.get(uri);
+        verify(downloader, times(2)).fetch(uri);
+    }
+    
 }


### PR DESCRIPTION
I've just made a change in order to be able to disable fetched schemas cache.
I find this capability useful during schema development, to be able to update the schemas without restarting my webservice.
