### PR TITLE
add (head) badges for short overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status][Travis badge]][Travis]
+
 ## Travis builds now enabled
 
 Builds are now verified by Travis (see [issue #20](https://github.com/daveclayton/json-patch/issues/20) from the json-patch project for details)
@@ -72,3 +74,5 @@ The versioning scheme is defined by the **middle digit** of the version number:
 * if this number is **odd**, then this is the **development** version; new features will be
   added to those versions only, **and the user API may change**.
 
+[Travis Badge]: https://api.travis-ci.org/daveclayton/json-schema-core.svg?branch=master
+[Travis]: https://travis-ci.org/daveclayton/json-schema-core

--- a/README.md
+++ b/README.md
@@ -3,12 +3,6 @@
 [![Build Status][Travis badge]][Travis]
 ![Maven Central](https://img.shields.io/maven-central/v/com.github.java-json-tools/json-schema-core.svg)
 
-## Travis builds now enabled
-
-Builds are now verified by Travis (see [issue #20](https://github.com/java-json-tools/json-patch/issues/20) from the json-patch project for details)
-
-https://travis-ci.org/daveclayton/json-schema-core
-
 ## Read me first
 
 The license of this project is dual licensed [LGPLv3] or later/[ASL 2.0]. See file `LICENSE` for more

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![License LGPLv3][LGPLv3 badge]][LGPLv3]
+[![License ASL 2.0][ASL 2.0 badge]][ASL 2.0]
 [![Build Status][Travis badge]][Travis]
 
 ## Travis builds now enabled
@@ -8,7 +10,7 @@ https://travis-ci.org/daveclayton/json-schema-core
 
 ## Read me first
 
-The license of this project is dual licensed LGPLv3 or later/ASL 2.0. See file `LICENSE` for more
+The license of this project is dual licensed [LGPLv3] or later/[ASL 2.0]. See file `LICENSE` for more
 details. The full text of both licensed is included in the package.
 
 ## What this is
@@ -74,5 +76,9 @@ The versioning scheme is defined by the **middle digit** of the version number:
 * if this number is **odd**, then this is the **development** version; new features will be
   added to those versions only, **and the user API may change**.
 
+[LGPLv3 badge]: https://img.shields.io/:license-LGPLv3-blue.svg
+[LGPLv3]: http://www.gnu.org/licenses/lgpl-3.0.html
+[ASL 2.0 badge]: https://img.shields.io/:license-Apache%202.0-blue.svg
+[ASL 2.0]: http://www.apache.org/licenses/LICENSE-2.0.html
 [Travis Badge]: https://api.travis-ci.org/daveclayton/json-schema-core.svg?branch=master
 [Travis]: https://travis-ci.org/daveclayton/json-schema-core

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![License LGPLv3][LGPLv3 badge]][LGPLv3]
 [![License ASL 2.0][ASL 2.0 badge]][ASL 2.0]
 [![Build Status][Travis badge]][Travis]
+![Maven Central](https://img.shields.io/maven-central/v/com.github.fge/json-schema-core.svg)
 
 ## Travis builds now enabled
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 [![License LGPLv3][LGPLv3 badge]][LGPLv3]
 [![License ASL 2.0][ASL 2.0 badge]][ASL 2.0]
 [![Build Status][Travis badge]][Travis]
-![Maven Central](https://img.shields.io/maven-central/v/com.github.fge/json-schema-core.svg)
+![Maven Central](https://img.shields.io/maven-central/v/com.github.java-json-tools/json-schema-core.svg)
 
 ## Travis builds now enabled
 
-Builds are now verified by Travis (see [issue #20](https://github.com/daveclayton/json-patch/issues/20) from the json-patch project for details)
+Builds are now verified by Travis (see [issue #20](https://github.com/java-json-tools/json-patch/issues/20) from the json-patch project for details)
 
 https://travis-ci.org/daveclayton/json-schema-core
 


### PR DESCRIPTION
[Shields.io](http://shields.io/) provide badges for different metadata. Add badges for Travis build status on master (branch), LGPLv3, Apache Software License 2.0 and for latest version on Maven Central.