### PR TITLE
Add ability to configure cache sizes in json-schema-core

### DIFF
--- a/src/main/java/com/github/fge/jsonschema/core/load/SchemaLoader.java
+++ b/src/main/java/com/github/fge/jsonschema/core/load/SchemaLoader.java
@@ -32,7 +32,6 @@ import com.github.fge.jsonschema.core.tree.SchemaTree;
 import com.github.fge.msgsimple.bundle.MessageBundle;
 import com.github.fge.msgsimple.load.MessageBundles;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheBuilderSpec;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableMap;
@@ -101,20 +100,20 @@ public final class SchemaLoader
         manager = new URIManager(cfg);
         preloadedSchemas = ImmutableMap.copyOf(cfg.getPreloadedSchemas());
 
-        final CacheBuilder<Object, Object> cacheBuilder = cfg.getEnableCache()
-            ? CacheBuilder.newBuilder()
-            : CacheBuilder.from(CacheBuilderSpec.disableCaching());
-        
-        cache = cacheBuilder.build(new CacheLoader<URI, JsonNode>()
-        {
-            @Nonnull
-            @Override
-            public JsonNode load(@Nonnull final URI key)
-                throws ProcessingException
+        CacheBuilder<Object, Object> builder = CacheBuilder.newBuilder();
+        if (cfg.getCacheSize() != -1) {
+        	builder.maximumSize(cfg.getCacheSize());
+        }
+        cache = builder.build(new CacheLoader<URI, JsonNode>()
             {
-                return manager.getContent(key);
-            }
-        });
+                @Nonnull
+                @Override
+                public JsonNode load(@Nonnull final URI key)
+                    throws ProcessingException
+                {
+                    return manager.getContent(key);
+                }
+            });
     }
 
     /**

--- a/src/main/java/com/github/fge/jsonschema/core/load/configuration/LoadingConfiguration.java
+++ b/src/main/java/com/github/fge/jsonschema/core/load/configuration/LoadingConfiguration.java
@@ -89,12 +89,12 @@ public final class LoadingConfiguration
     final URITranslatorConfiguration translatorCfg;
     
     /**
-     * Should we cache schemas
+     * Cache size
      *
      * <p>Note that this do not affect preloaded schemas; these are always
      * cached.</p>
      */
-    final boolean enableCache;
+    final int cacheSize;
 
     /**
      * Dereferencing mode
@@ -165,7 +165,7 @@ public final class LoadingConfiguration
         preloadedSchemas = ImmutableMap.copyOf(builder.preloadedSchemas);
         parserFeatures = EnumSet.copyOf(builder.parserFeatures);
         reader = buildReader();
-        enableCache = builder.enableCache;
+        cacheSize = builder.cacheSize;
     }
 
     /**
@@ -237,10 +237,23 @@ public final class LoadingConfiguration
      * Return if we want to cache loaded schema or not
      * note that this do not affect preloadedSchema that are always cached
      * 
+     * @deprecated Use cacheSize getter instead to get the cache size
+     * 
      * @return if the cache has to be enabled
      */
+    @Deprecated
     public boolean getEnableCache() {
-        return enableCache;
+        return this.cacheSize != 0;
+    }
+    
+    /**
+     * Return the size of the cache to use
+     * note that this do not affect preloadedSchema that are always cached
+     *
+     * @return the size of the cache. A zero-value means that it is not enabled
+     */
+    public int getCacheSize() {
+        return cacheSize;
     }
 
     /**

--- a/src/main/java/com/github/fge/jsonschema/core/load/configuration/LoadingConfigurationBuilder.java
+++ b/src/main/java/com/github/fge/jsonschema/core/load/configuration/LoadingConfigurationBuilder.java
@@ -57,6 +57,8 @@ public final class LoadingConfigurationBuilder
      * EnumSets to collect them, so we have to do that...
      */
     private static final EnumSet<JsonParser.Feature> DEFAULT_PARSER_FEATURES;
+    
+    private static final int DEFAULT_CACHE_SIZE = 512;
 
     static {
         DEFAULT_PARSER_FEATURES = EnumSet.noneOf(JsonParser.Feature.class);
@@ -78,9 +80,9 @@ public final class LoadingConfigurationBuilder
     URITranslatorConfiguration translatorCfg;
 
     /**
-     * Loaded schemas are cached by default
+     * Cache size is 512 by default
      */
-    boolean enableCache = true;
+    int cacheSize = DEFAULT_CACHE_SIZE;
 
     /**
      * Dereferencing mode
@@ -132,20 +134,39 @@ public final class LoadingConfigurationBuilder
         dereferencing = cfg.dereferencing;
         preloadedSchemas = Maps.newHashMap(cfg.preloadedSchemas);
         parserFeatures = EnumSet.copyOf(cfg.parserFeatures);
-        enableCache = cfg.enableCache;
+        cacheSize = cfg.cacheSize;
     }
-
+    
     /**
      * Should we enable caching of downloaded schemas
+     * 
+     * @deprecated Just for backward compatibility
+     *     Use cacheSize setter instead to set the maximum size of the cache
      *
      * <p>Note that this does <b>not</b> affect preloaded schemas</p>
      * 
      * @param enableCache if loaded schemas have to be cached
      * @return this
      */
+    @Deprecated
     public LoadingConfigurationBuilder setEnableCache(final boolean enableCache)
     {
-        this.enableCache = enableCache;
+    	this.cacheSize = enableCache ? DEFAULT_CACHE_SIZE : 0;
+        return this;
+    }
+
+    /**
+     * How many schemas should be cached
+     * <p>Note setting to zero effectively disables the cache</p>
+     * <p>Note settting to -1 creates an unlimited cache</p>
+     * <p>Note that this does <b>not</b> affect preloaded schemas</p>
+     *
+     * @param cacheSize if loaded schemas have to be cached
+     * @return this
+     */
+    public LoadingConfigurationBuilder setCacheSize(final int cacheSize)
+    {
+        this.cacheSize = cacheSize;
         return this;
     }
     

--- a/src/main/java/com/github/fge/jsonschema/core/processing/CachingProcessor.java
+++ b/src/main/java/com/github/fge/jsonschema/core/processing/CachingProcessor.java
@@ -53,6 +53,8 @@ public final class CachingProcessor<IN extends MessageProvider, OUT extends Mess
     private static final MessageBundle BUNDLE
         = MessageBundles.getBundle(JsonSchemaCoreMessageBundle.class);
 
+    private static final int DEFAULT_CACHE_SIZE = 512;
+
     /**
      * The wrapped processor
      */
@@ -83,21 +85,32 @@ public final class CachingProcessor<IN extends MessageProvider, OUT extends Mess
         this(processor, Equivalences.<IN>equals());
     }
 
+    public CachingProcessor(final Processor<IN, OUT> processor,
+        final Equivalence<IN> equivalence)
+    {
+        this(processor, equivalence, DEFAULT_CACHE_SIZE);
+    }
     /**
      * Main constructor
      *
      * @param processor the processor
      * @param equivalence an equivalence to use for cache keys
-     * @throws NullPointerException processor or equivalence are null
+     * @param cacheSize the size of the cache, zero disables it
+     * @throws NullPointerException processor or equivalence
      */
     public CachingProcessor(final Processor<IN, OUT> processor,
-        final Equivalence<IN> equivalence)
+        final Equivalence<IN> equivalence, final int cacheSize)
     {
         BUNDLE.checkNotNull(processor, "processing.nullProcessor");
         BUNDLE.checkNotNull(equivalence, "processing.nullEquivalence");
+        BUNDLE.checkArgument(cacheSize >= -1, "processing.invalidCacheSize");
         this.processor = processor;
         this.equivalence = equivalence;
-        cache = CacheBuilder.newBuilder().build(loader());
+        CacheBuilder<Object, Object> builder = CacheBuilder.newBuilder();
+        if (cacheSize != -1) {
+        	builder.maximumSize(cacheSize);
+        }
+        cache = builder.build(loader());
     }
 
     @Override

--- a/src/main/resources/com/github/fge/jsonschema/core/core.properties
+++ b/src/main/resources/com/github/fge/jsonschema/core/core.properties
@@ -48,6 +48,7 @@ processing.nullLevel = log level must not be null
 processing.nullPredicate = predicate cannot be null
 processing.nullProcessor = processor cannot be null
 processing.nullReport = report cannot be null
+processing.invalidCacheSize = cache size must be greater than -1. -1 value sets a cache with unlimited records, zero-value disables the cache
 refProcessing.danglingRef = JSON Reference "%s" cannot be resolved
 refProcessing.refLoop = JSON Reference "%s" loops on itself
 refProcessing.unhandledScheme = URI scheme "%s" not supported (URI: "%s")

--- a/src/test/java/com/github/fge/jsonschema/core/load/SchemaLoaderTest.java
+++ b/src/test/java/com/github/fge/jsonschema/core/load/SchemaLoaderTest.java
@@ -100,7 +100,7 @@ public final class SchemaLoaderTest
         final SchemaTree tree = loader.get(URI.create(location));
 
         assertEquals(tree.getLoadingRef().toURI(),
-            URI.create("http://toto/b#"));
+                URI.create("http://toto/b#"));
     }
 
     @Test
@@ -141,7 +141,7 @@ public final class SchemaLoaderTest
         verify(mock, never()).fetch(uri);
 
         //even if cache is disabled
-        cfg = builder.setEnableCache(false).freeze();
+        cfg = builder.setCacheSize(0).freeze();
         registry = new SchemaLoader(cfg);
         registry.get(uri);
         verify(mock, never()).fetch(uri);        
@@ -152,12 +152,10 @@ public final class SchemaLoaderTest
         throws ProcessingException, IOException
     {
         final URI uri = URI.create("foo:/baz#");
-        final URIDownloader downloader = spy(new URIDownloader()
-        {
+        final URIDownloader downloader = spy(new URIDownloader() {
             @Override
             public InputStream fetch(final URI source)
-                throws IOException
-            {
+                    throws IOException {
                 return new ByteArrayInputStream(BYTES);
             }
         });
@@ -176,6 +174,30 @@ public final class SchemaLoaderTest
         throws ProcessingException, IOException
     {
         final URI uri = URI.create("foo:/baz#");
+        final URIDownloader downloader = spy(new URIDownloader() {
+            @Override
+            public InputStream fetch(final URI source)
+                    throws IOException {
+                return new ByteArrayInputStream(BYTES);
+            }
+        });
+
+        final LoadingConfiguration cfg = LoadingConfiguration.newBuilder()
+            .addScheme("foo", downloader)
+            .setCacheSize(0)
+            .freeze();
+        final SchemaLoader loader = new SchemaLoader(cfg);
+
+        loader.get(uri);
+        loader.get(uri);
+        verify(downloader, times(2)).fetch(uri);
+    }
+
+    @Test
+    public void schemasCacheCanBeDisabledViaCacheSize()
+        throws ProcessingException, IOException
+    {
+        final URI uri = URI.create("foo:/baz#");
         final URIDownloader downloader = spy(new URIDownloader()
         {
             @Override
@@ -187,12 +209,13 @@ public final class SchemaLoaderTest
         });
 
         final LoadingConfiguration cfg = LoadingConfiguration.newBuilder()
-            .addScheme("foo", downloader).setEnableCache(false).freeze();
+            .addScheme("foo", downloader)
+            .setCacheSize(0)
+            .freeze();
         final SchemaLoader loader = new SchemaLoader(cfg);
 
         loader.get(uri);
         loader.get(uri);
         verify(downloader, times(2)).fetch(uri);
     }
-    
 }

--- a/src/test/java/com/github/fge/jsonschema/core/processing/CachingProcessorTest.java
+++ b/src/test/java/com/github/fge/jsonschema/core/processing/CachingProcessorTest.java
@@ -75,6 +75,18 @@ public final class CachingProcessorTest
     }
 
     @Test
+    public void cannotInputInvalidCacheSize()
+    {
+        try {
+            new CachingProcessor<In, Out>(processor, Equivalences.<In>identity(), -2);
+            fail("No exception thrown!!");
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(),
+                BUNDLE.getMessage("processing.invalidCacheSize"));
+        }
+    }
+
+    @Test
     public void cachedValueIsNotProcessedTwiceButReportedTwice()
         throws ProcessingException
     {
@@ -87,6 +99,23 @@ public final class CachingProcessorTest
         p.process(report, input);
 
         verify(processor, only()).process(anyReport(), same(input));
+        verify(report, times(2)).mergeWith(anyReport());
+    }
+
+
+    @Test
+    public void cachedValueIsProcessedTwiceWithMaximumSizeZero()
+        throws ProcessingException
+    {
+        final Processor<In, Out> p = new CachingProcessor<In, Out>(processor,
+            Equivalences.<In>identity(), 0);
+
+        final ProcessingReport report = mock(ProcessingReport.class);
+
+        p.process(report, input);
+        p.process(report, input);
+
+        verify(processor, times(2)).process(anyReport(), same(input));
         verify(report, times(2)).mergeWith(anyReport());
     }
 


### PR DESCRIPTION
Context: The CachingProcessors, due to their infinite caching,
are leading to memory exhaustion on some of our long running
service nodes.
