### PR TITLE
Issue 38: adding support for Nashorn as ECMA 262 capable script engine

### DIFF
--- a/src/main/java/com/github/fge/jsonschema/core/keyword/syntax/checkers/common/PatternPropertiesSyntaxChecker.java
+++ b/src/main/java/com/github/fge/jsonschema/core/keyword/syntax/checkers/common/PatternPropertiesSyntaxChecker.java
@@ -24,7 +24,7 @@ import com.github.fge.jsonschema.core.report.ProcessingReport;
 import com.github.fge.jsonschema.core.keyword.syntax.checkers.SyntaxChecker;
 import com.github.fge.jsonschema.core.keyword.syntax.checkers.helpers.SchemaMapSyntaxChecker;
 import com.github.fge.jsonschema.core.tree.SchemaTree;
-import com.github.fge.jsonschema.core.util.RhinoHelper;
+import com.github.fge.jsonschema.core.util.RegexECMA262Helper;
 import com.github.fge.msgsimple.bundle.MessageBundle;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
@@ -34,7 +34,7 @@ import java.util.Set;
 /**
  * Syntax checker for the {@code patternProperties} keyword
  *
- * @see RhinoHelper
+ * @see RegexECMA262Helper
  */
 public final class PatternPropertiesSyntaxChecker
     extends SchemaMapSyntaxChecker
@@ -63,7 +63,7 @@ public final class PatternPropertiesSyntaxChecker
         final Set<String> set = Sets.newHashSet(getNode(tree).fieldNames());
 
         for (final String s: Ordering.natural().sortedCopy(set))
-            if (!RhinoHelper.regexIsValid(s))
+            if (!RegexECMA262Helper.regexIsValid(s))
                 report.error(newMsg(tree, bundle,
                     "common.patternProperties.member.notRegex")
                     .putArgument("propertyName", s));

--- a/src/main/java/com/github/fge/jsonschema/core/keyword/syntax/checkers/common/PatternSyntaxChecker.java
+++ b/src/main/java/com/github/fge/jsonschema/core/keyword/syntax/checkers/common/PatternSyntaxChecker.java
@@ -26,7 +26,7 @@ import com.github.fge.jsonschema.core.report.ProcessingReport;
 import com.github.fge.jsonschema.core.keyword.syntax.checkers.AbstractSyntaxChecker;
 import com.github.fge.jsonschema.core.keyword.syntax.checkers.SyntaxChecker;
 import com.github.fge.jsonschema.core.tree.SchemaTree;
-import com.github.fge.jsonschema.core.util.RhinoHelper;
+import com.github.fge.jsonschema.core.util.RegexECMA262Helper;
 import com.github.fge.msgsimple.bundle.MessageBundle;
 
 import java.util.Collection;
@@ -34,7 +34,7 @@ import java.util.Collection;
 /**
  * Syntax checker for the {@code pattern} keyword
  *
- * @see RhinoHelper
+ * @see RegexECMA262Helper
  */
 public final class PatternSyntaxChecker
     extends AbstractSyntaxChecker
@@ -59,7 +59,7 @@ public final class PatternSyntaxChecker
     {
         final String value = getNode(tree).textValue();
 
-        if (!RhinoHelper.regexIsValid(value))
+        if (!RegexECMA262Helper.regexIsValid(value))
             report.error(newMsg(tree, bundle, "common.invalidRegex")
                 .putArgument("value", value));
     }

--- a/src/main/java/com/github/fge/jsonschema/core/util/RegexECMA262Helper.java
+++ b/src/main/java/com/github/fge/jsonschema/core/util/RegexECMA262Helper.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2014, Francis Galiegue (fgaliegue@gmail.com)
+ *
+ * This software is dual-licensed under:
+ *
+ * - the Lesser General Public License (LGPL) version 3.0 or, at your option, any
+ *   later version;
+ * - the Apache Software License (ASL) version 2.0.
+ *
+ * The text of this file and of both licenses is available at the root of this
+ * project or, if you have the jar distribution, in directory META-INF/, under
+ * the names LGPL-3.0.txt and ASL-2.0.txt respectively.
+ *
+ * Direct link to the sources:
+ *
+ * - LGPL 3.0: https://www.gnu.org/licenses/lgpl-3.0.txt
+ * - ASL 2.0: http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+
+package com.github.fge.jsonschema.core.util;
+
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Function;
+import org.mozilla.javascript.Scriptable;
+
+import javax.annotation.concurrent.ThreadSafe;
+import javax.script.Invocable;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+
+import java.util.regex.Pattern;
+
+/**
+ * <p>ECMA 262 validation helper. A script engine is used instead of {@link
+ * java.util.regex} because the latter doesn't comply with ECMA 262:</p>
+ *
+ * <ul>
+ *     <li>ECMA 262 doesn't have {@link Pattern#DOTALL};</li>
+ *     <li>ECMA 262 doesn't have "possessive" quantifiers ({@code ++},
+ *     {@code ?+}, etc);</li>
+ *     <li>there is only one word delimiter in ECMA 262, which is {@code \b};
+ *     {@code \<} (for beginning of word) and {@code \>} (for end of word) are
+ *     not understood.</li>
+ * </ul>
+ *
+ * <p>And many, many other things. See
+ * <a href="http://www.regular-expressions.info/javascript.html">here</a> for
+ * the full story. And if you don't yet have Jeffrey Friedl's "Mastering regular
+ * expressions", just <a href="http://regex.info">buy it</a> :p</p>
+ *
+ * <p>As script engine is used either Nashorn or Rhino as its fallback.
+ * Nashorn is only available on Java 8 runtimes or higher.</p>
+ *
+ * <p>Rhino is only the fallback as it is tremendously slower.</p>
+ */
+@ThreadSafe
+public final class RegexECMA262Helper
+{
+    private static final String REGEX_IS_VALID_FUNCTION_NAME = "regexIsValid";
+
+    private static final String REG_MATCH_FUNCTION_NAME = "regMatch";
+
+    /**
+     * JavaScript scriptlet defining functions {@link #REGEX_IS_VALID}
+     * and {@link #REG_MATCH}
+     */
+    private static final String jsAsString
+        = "function " + REGEX_IS_VALID_FUNCTION_NAME + "(re)"
+        + '{'
+        + "    try {"
+        + "         new RegExp(re);"
+        + "         return true;"
+        + "    } catch (e) {"
+        + "        return false;"
+        + "    }"
+        + '}'
+        + ""
+        + "function " + REG_MATCH_FUNCTION_NAME + "(re, input)"
+        + '{'
+        + "    return new RegExp(re).test(input);"
+        + '}';
+
+    /**
+     * Script scope
+     */
+    private static final Scriptable SCOPE;
+
+    /**
+     * Reference to Javascript function for regex validation
+     */
+    private static final Function REGEX_IS_VALID;
+
+    /**
+     * Reference to Javascript function for regex matching
+     */
+    private static final Function REG_MATCH;
+
+    private static final Invocable PRIMARY_SCRIPT_ENGINE;
+
+    private RegexECMA262Helper()
+    {
+    }
+
+    static {
+        PRIMARY_SCRIPT_ENGINE = tryResolvePrimaryEngine();
+
+        final Context ctx = Context.enter();
+        try {
+            SCOPE = ctx.initStandardObjects(null, false);
+            try {
+                ctx.evaluateString(SCOPE, jsAsString, "re", 1, null);
+            } catch(UnsupportedOperationException e) {
+                // See: http://stackoverflow.com/questions/3859305/problems-using-rhino-on-android
+                ctx.setOptimizationLevel(-1);
+                ctx.evaluateString(SCOPE, jsAsString, "re", 1, null);
+            }
+            REGEX_IS_VALID = (Function) SCOPE.get(REGEX_IS_VALID_FUNCTION_NAME, SCOPE);
+            REG_MATCH = (Function) SCOPE.get(REG_MATCH_FUNCTION_NAME, SCOPE);
+        } finally {
+            Context.exit();
+        }
+    }
+
+    private static Invocable tryResolvePrimaryEngine() {
+        final ScriptEngine engine = new ScriptEngineManager()
+                .getEngineByName("nashorn");
+        if(engine != null) {
+            try {
+                engine.eval(jsAsString);
+                return (Invocable) engine;
+            } catch(final ScriptException e) {
+                // the script can't be parsed - the script engine can't be used
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Validate that a regex is correct
+     *
+     * @param regex the regex to validate
+     * @return true if the regex is valid
+     */
+    public static boolean regexIsValid(final String regex)
+    {
+        if(PRIMARY_SCRIPT_ENGINE != null)
+        {
+            return invokeScriptEngine(REGEX_IS_VALID_FUNCTION_NAME, regex);
+        }
+        return invokeFallbackEngine(REGEX_IS_VALID, regex);
+    }
+
+    /**
+     * <p>Matches an input against a given regex, in the <b>real</b> sense
+     * of matching, that is, the regex can match anywhere in the input. Java's
+     * {@link java.util.regex} makes the unfortunate mistake to make people
+     * believe that matching is done on the whole input... Which is not true.
+     * </p>
+     *
+     * <p>Also note that the regex MUST have been validated at this point
+     * (using {@link #regexIsValid(String)}).</p>
+     *
+     * @param regex the regex to use
+     * @param input the input to match against (and again, see description)
+     * @return true if the regex matches the input
+     */
+    public static boolean regMatch(final String regex, final String input)
+    {
+        if(PRIMARY_SCRIPT_ENGINE != null)
+        {
+            return invokeScriptEngine(REG_MATCH_FUNCTION_NAME, regex, input);
+        }
+        return invokeFallbackEngine(REG_MATCH, regex, input);
+    }
+
+    private static boolean invokeScriptEngine(final String function,
+                                              final Object... values)
+    {
+        try {
+            return (Boolean) PRIMARY_SCRIPT_ENGINE.invokeFunction(function,
+                    values);
+        } catch(final ScriptException e) {
+            throw new IllegalStateException(
+                    "Unexpected error on invoking Script.", e);
+        } catch(final NoSuchMethodException e) {
+            throw new IllegalStateException(
+                    "Unexpected error on invoking Script.", e);
+        }
+    }
+
+    private static boolean invokeFallbackEngine(final Function function,
+                                                final Object... values)
+    {
+        final Context context = Context.enter();
+        try {
+            return (Boolean) function.call(context, SCOPE, SCOPE, values);
+        } finally {
+            Context.exit();
+        }
+    }
+}

--- a/src/main/java/com/github/fge/jsonschema/core/util/RhinoHelper.java
+++ b/src/main/java/com/github/fge/jsonschema/core/util/RhinoHelper.java
@@ -19,106 +19,27 @@
 
 package com.github.fge.jsonschema.core.util;
 
-import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Function;
-import org.mozilla.javascript.Scriptable;
-
 import javax.annotation.concurrent.ThreadSafe;
-import java.util.regex.Pattern;
 
 /**
- * <p>ECMA 262 validation helper. Rhino is used instead of {@link
- * java.util.regex} because the latter doesn't comply with ECMA 262:</p>
- *
- * <ul>
- *     <li>ECMA 262 doesn't have {@link Pattern#DOTALL};</li>
- *     <li>ECMA 262 doesn't have "possessive" quantifiers ({@code ++},
- *     {@code ?+}, etc);</li>
- *     <li>there is only one word delimiter in ECMA 262, which is {@code \b};
- *     {@code \<} (for beginning of word) and {@code \>} (for end of word) are
- *     not understood.</li>
- * </ul>
- *
- * <p>And many, many other things. See
- * <a href="http://www.regular-expressions.info/javascript.html">here</a> for
- * the full story. And if you don't yet have Jeffrey Friedl's "Mastering regular
- * expressions", just <a href="http://regex.info">buy it</a> :p</p>
+ * @see RegexECMA262Helper
+ * @deprecated use {@link RegexECMA262Helper} as 1:1 replacement
  */
 @ThreadSafe
+@Deprecated
 public final class RhinoHelper
 {
-    /**
-     * JavaScript scriptlet defining functions {@link #REGEX_IS_VALID}
-     * and {@link #REG_MATCH}
-     */
-    private static final String jsAsString
-        = "function regexIsValid(re)"
-        + '{'
-        + "    try {"
-        + "         new RegExp(re);"
-        + "         return true;"
-        + "    } catch (e) {"
-        + "        return false;"
-        + "    }"
-        + '}'
-        + ""
-        + "function regMatch(re, input)"
-        + '{'
-        + "    return new RegExp(re).test(input);"
-        + '}';
-
-    /**
-     * Script scope
-     */
-    private static final Scriptable SCOPE;
-
-    /**
-     * Reference to Javascript function for regex validation
-     */
-    private static final Function REGEX_IS_VALID;
-
-    /**
-     * Reference to Javascript function for regex matching
-     */
-    private static final Function REG_MATCH;
-
-    private RhinoHelper()
-    {
-    }
-
-    static {
-        final Context ctx = Context.enter();
-        try {
-            SCOPE = ctx.initStandardObjects(null, false);
-            try {
-                ctx.evaluateString(SCOPE, jsAsString, "re", 1, null);
-            } catch(UnsupportedOperationException e) {
-                // See: http://stackoverflow.com/questions/3859305/problems-using-rhino-on-android
-                ctx.setOptimizationLevel(-1);
-                ctx.evaluateString(SCOPE, jsAsString, "re", 1, null);
-            }
-            REGEX_IS_VALID = (Function) SCOPE.get("regexIsValid", SCOPE);
-            REG_MATCH = (Function) SCOPE.get("regMatch", SCOPE);
-        } finally {
-            Context.exit();
-        }
-    }
-
     /**
      * Validate that a regex is correct
      *
      * @param regex the regex to validate
      * @return true if the regex is valid
+     * @deprecated use {@link RegexECMA262Helper#regexIsValid(String)}
      */
+    @Deprecated
     public static boolean regexIsValid(final String regex)
     {
-        final Context context = Context.enter();
-        try {
-            return (Boolean) REGEX_IS_VALID.call(context, SCOPE, SCOPE,
-                new Object[]{ regex });
-        } finally {
-            Context.exit();
-        }
+        return RegexECMA262Helper.regexIsValid(regex);
     }
 
     /**
@@ -134,16 +55,11 @@ public final class RhinoHelper
      * @param regex the regex to use
      * @param input the input to match against (and again, see description)
      * @return true if the regex matches the input
+     * @deprecated use {@link RegexECMA262Helper#regMatch(String, String)}
      */
+    @Deprecated
     public static boolean regMatch(final String regex, final String input)
     {
-        final Context context = Context.enter();
-        try {
-            return (Boolean) REG_MATCH.call(context, SCOPE, SCOPE,
-                new Object[]{ regex, input });
-        } finally {
-            Context.exit();
-        }
-
+        return RegexECMA262Helper.regMatch(regex, input);
     }
 }

--- a/src/main/java/com/github/fge/jsonschema/core/util/package-info.java
+++ b/src/main/java/com/github/fge/jsonschema/core/util/package-info.java
@@ -20,7 +20,7 @@
 /**
  * Various utility classes
  *
- * <p>{@link com.github.fge.jsonschema.core.util.RhinoHelper} is in charge of
+ * <p>{@link com.github.fge.jsonschema.core.util.RegexECMA262Helper} is in charge of
  * all regex validation: as the standard dictates ECMA 262 regexes, using {@link
  * java.util.regex} is out of the question. See this class' description for more
  * details.</p>

--- a/src/test/java/com/github/fge/jsonschema/core/util/RegexECMA262HelperTest.java
+++ b/src/test/java/com/github/fge/jsonschema/core/util/RegexECMA262HelperTest.java
@@ -27,7 +27,7 @@ import java.util.Iterator;
 
 import static org.testng.Assert.*;
 
-public final class RhinoHelperTest
+public final class RegexECMA262HelperTest
 {
     @DataProvider
     public Iterator<Object[]> ecma262regexes()
@@ -48,6 +48,7 @@ public final class RhinoHelperTest
     public void regexesAreCorrectlyAnalyzed(final String regex,
         final boolean valid)
     {
+        assertEquals(RegexECMA262Helper.regexIsValid(regex), valid);
         assertEquals(RhinoHelper.regexIsValid(regex), valid);
     }
 
@@ -58,6 +59,8 @@ public final class RhinoHelperTest
             new Object[] { "[^a-z]", "9am", true },
             new Object[] { "bar\\d+", "foobar19ae", true },
             new Object[] { "^bar\\d+", "bar", false },
+            new Object[] { "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$", "QmFzZTY0IFN0cmluZwo=", true }, // Base64 regex match
+            new Object[] { "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$", "QmFzZTY0IFN0cmluZwo", false }, // Base64 regex match
             new Object[] { "[a-z]+(?!foo)(?=bar)", "3aaaabar", true }
         ).iterator();
     }
@@ -70,6 +73,7 @@ public final class RhinoHelperTest
     public void regexMatchingIsDoneCorrectly(final String regex,
         final String input, final boolean valid)
     {
+        assertEquals(RegexECMA262Helper.regMatch(regex, input), valid);
         assertEquals(RhinoHelper.regMatch(regex, input), valid);
     }
 }


### PR DESCRIPTION
This pull requests adds support for the Nashorn script engine newly introduced in Java 8.

This enables a far more faster regex support for users using a Java 8 or higher runtime.

In case a runtime is used which does not have Nashorn nothing will change. Then Rhino is still in place as Nashorns fallback.


A new class RegexECMA262Helper was introduced, which fits better to the purpose this class has. RhinoHelper could been called like that, because it only checks ECMA 262 regular expressions.

RhinoHelper was kept and marked as deprecated. RegexECMA262Helper is its 1:1 replacement.