### PR TITLE
using class loader of SchemaVersion (instead of JsonLoader)

### DIFF
--- a/src/main/java/com/github/fge/jsonschema/SchemaVersion.java
+++ b/src/main/java/com/github/fge/jsonschema/SchemaVersion.java
@@ -25,6 +25,7 @@ import com.github.fge.jsonschema.core.ref.JsonRef;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URL;
 
 /**
  * JSON Schema versions
@@ -60,7 +61,8 @@ public enum SchemaVersion
     {
         try {
             location = URI.create(uri);
-            schema = JsonLoader.fromResource(resource);
+            final URL url = SchemaVersion.class.getResource(resource);
+            schema = JsonLoader.fromURL(url);
         } catch (IOException e) {
             throw new ExceptionInInitializerError(e);
         }


### PR DESCRIPTION
Class loader of JsonLoader is used by default and resources packaged in json-schema-core (resources/draftv3/*, resources/draftv4/*). Resources are not loadable (enumeration is not initialized) in OSGi environment because bundles (JARs) have different classloaders.