### PR TITLE
Use JsonPointer.path in all BaseSchemaTree constructors.

### DIFF
--- a/src/main/java/com/github/fge/jsonschema/core/tree/BaseSchemaTree.java
+++ b/src/main/java/com/github/fge/jsonschema/core/tree/BaseSchemaTree.java
@@ -139,7 +139,7 @@ public abstract class BaseSchemaTree
         baseNode = other.baseNode;
 
         pointer = newPointer;
-        node = newPointer.get(baseNode);
+        node = newPointer.path(baseNode);
 
         startingRef = other.startingRef;
         currentRef = nextRef(startingRef, newPointer, baseNode);

--- a/src/test/java/com/github/fge/jsonschema/core/tree/SchemaTreeTest.java
+++ b/src/test/java/com/github/fge/jsonschema/core/tree/SchemaTreeTest.java
@@ -250,4 +250,17 @@ public final class SchemaTreeTest
 
         assertNotEquals(tree, tree2);
     }
+
+    @Test
+    public void danglingRefToSubschema() throws JsonPointerException
+    {
+        final ObjectNode node = FACTORY.objectNode();
+        final SchemaTree tree
+             = new CanonicalSchemaTree(SchemaKey.anonymousKey(), node);
+        assertNotEquals(tree, null);
+        final SchemaTree subtree = tree.setPointer(new JsonPointer("/missing"));
+        assertNotEquals(subtree, null);
+        assertNotEquals(subtree.getNode(), null);
+        assertEquals(subtree.getNode().isMissingNode(), true);
+    }
 }


### PR DESCRIPTION
The other two constructors already use `JsonPointer.path` to ensure that the tree node is non-null, providing the missing node as necessary. This last constructor, invoked via `SchemaTree.setPointer`, used `JsonPointer.get`, which would just return a `null` value, which would later cause NPEs when fetched and used.

Fixes #55.