### PR TITLE
Many warnings fixes.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,6 @@ dependencies {
     compile(group: "com.github.fge", name: "uri-template", version: "0.9");
     // FIXME: no javadoc
     compile(group: "org.mozilla", name: "rhino", version: "1.7.7.1");
-    compile(group: "com.google.code.findbugs", name: "jsr305", version: "3.0.2");
     testCompile(group: "org.testng", name: "testng", version: "6.10") {
         exclude(group: "junit", module: "junit");
         exclude(group: "org.beanshell", module: "bsh");

--- a/src/main/java/com/github/fge/jsonschema/SchemaVersion.java
+++ b/src/main/java/com/github/fge/jsonschema/SchemaVersion.java
@@ -54,6 +54,7 @@ public enum SchemaVersion
     ;
 
     private final URI location;
+    @SuppressWarnings("ImmutableEnumChecker")
     private final JsonNode schema;
 
     SchemaVersion(final String uri, final String resource)

--- a/src/main/java/com/github/fge/jsonschema/core/exceptions/InvalidSchemaException.java
+++ b/src/main/java/com/github/fge/jsonschema/core/exceptions/InvalidSchemaException.java
@@ -27,6 +27,8 @@ import com.github.fge.jsonschema.core.report.ProcessingMessage;
 public final class InvalidSchemaException
     extends ProcessingException
 {
+    private static final long serialVersionUID = 278790633227462029L;
+
     public InvalidSchemaException(final ProcessingMessage message)
     {
         super(message);

--- a/src/main/java/com/github/fge/jsonschema/core/exceptions/JsonReferenceException.java
+++ b/src/main/java/com/github/fge/jsonschema/core/exceptions/JsonReferenceException.java
@@ -32,6 +32,8 @@ import com.github.fge.jsonschema.core.report.ProcessingMessage;
 public final class JsonReferenceException
     extends ProcessingException
 {
+    private static final long serialVersionUID = 2630907528006411833L;
+
     public JsonReferenceException(final ProcessingMessage message)
     {
         super(message);

--- a/src/main/java/com/github/fge/jsonschema/core/exceptions/ProcessingException.java
+++ b/src/main/java/com/github/fge/jsonschema/core/exceptions/ProcessingException.java
@@ -35,6 +35,8 @@ import com.github.fge.jsonschema.core.report.ProcessingMessage;
 public class ProcessingException
     extends Exception
 {
+    private static final long serialVersionUID = -4194415456857460489L;
+
     /**
      * The internal message
      */

--- a/src/main/java/com/github/fge/jsonschema/core/keyword/syntax/checkers/SyntaxChecker.java
+++ b/src/main/java/com/github/fge/jsonschema/core/keyword/syntax/checkers/SyntaxChecker.java
@@ -47,7 +47,6 @@ import java.util.EnumSet;
 public interface SyntaxChecker
 {
     // FIXME: I should get rid of that -- it is used in only one place.
-    @VisibleForTesting
     EnumSet<NodeType> getValidTypes();
 
     /**

--- a/src/main/java/com/github/fge/jsonschema/core/keyword/syntax/checkers/hyperschema/LinksSyntaxChecker.java
+++ b/src/main/java/com/github/fge/jsonschema/core/keyword/syntax/checkers/hyperschema/LinksSyntaxChecker.java
@@ -23,10 +23,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.github.fge.jackson.NodeType;
 import com.github.fge.jackson.jsonpointer.JsonPointer;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
-import com.github.fge.jsonschema.core.report.ProcessingMessage;
-import com.github.fge.jsonschema.core.report.ProcessingReport;
 import com.github.fge.jsonschema.core.keyword.syntax.checkers.AbstractSyntaxChecker;
 import com.github.fge.jsonschema.core.keyword.syntax.checkers.SyntaxChecker;
+import com.github.fge.jsonschema.core.report.ProcessingMessage;
+import com.github.fge.jsonschema.core.report.ProcessingReport;
 import com.github.fge.jsonschema.core.tree.SchemaTree;
 import com.github.fge.msgsimple.bundle.MessageBundle;
 import com.github.fge.uritemplate.URITemplate;
@@ -46,7 +46,7 @@ import java.util.Set;
 public final class LinksSyntaxChecker
     extends AbstractSyntaxChecker
 {
-    private static final List<String> REQUIRED_LDO_PROPERTIES
+    private static final ImmutableList<String> REQUIRED_LDO_PROPERTIES
         = ImmutableList.of("href", "rel");
 
     private static final SyntaxChecker INSTANCE = new LinksSyntaxChecker();

--- a/src/main/java/com/github/fge/jsonschema/core/keyword/syntax/checkers/hyperschema/MediaSyntaxChecker.java
+++ b/src/main/java/com/github/fge/jsonschema/core/keyword/syntax/checkers/hyperschema/MediaSyntaxChecker.java
@@ -23,16 +23,15 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.github.fge.jackson.NodeType;
 import com.github.fge.jackson.jsonpointer.JsonPointer;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
-import com.github.fge.jsonschema.core.report.ProcessingReport;
 import com.github.fge.jsonschema.core.keyword.syntax.checkers.AbstractSyntaxChecker;
 import com.github.fge.jsonschema.core.keyword.syntax.checkers.SyntaxChecker;
+import com.github.fge.jsonschema.core.report.ProcessingReport;
 import com.github.fge.jsonschema.core.tree.SchemaTree;
 import com.github.fge.msgsimple.bundle.MessageBundle;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.MediaType;
 
 import java.util.Collection;
-import java.util.Set;
 
 /**
  * Syntax checker for draft v4 hyperschema's {@code media} keyword
@@ -44,7 +43,7 @@ public final class MediaSyntaxChecker
     private static final String TYPE_FIELDNAME = "type";
 
     // FIXME: INCOMPLETE: excludes "x-token" and "ietf-token"
-    private static final Set<String> BINARY_ENCODINGS = ImmutableSet.of(
+    private static final ImmutableSet<String> BINARY_ENCODINGS = ImmutableSet.of(
         "7bit", "8bit", "binary", "quoted-printable", "base64"
     );
 

--- a/src/main/java/com/github/fge/jsonschema/core/report/AbstractProcessingReport.java
+++ b/src/main/java/com/github/fge/jsonschema/core/report/AbstractProcessingReport.java
@@ -21,7 +21,6 @@ package com.github.fge.jsonschema.core.report;
 
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 
 import java.util.Iterator;

--- a/src/main/java/com/github/fge/jsonschema/core/report/ProcessingMessage.java
+++ b/src/main/java/com/github/fge/jsonschema/core/report/ProcessingMessage.java
@@ -378,7 +378,7 @@ public final class ProcessingMessage
     public JsonNode asJson()
     {
         final ObjectNode ret = FACTORY.objectNode();
-        ret.putAll(map);
+        ret.setAll(map);
         return ret;
     }
 

--- a/src/main/java/com/github/fge/jsonschema/core/tree/BaseSchemaTree.java
+++ b/src/main/java/com/github/fge/jsonschema/core/tree/BaseSchemaTree.java
@@ -28,7 +28,6 @@ import com.github.fge.jackson.jsonpointer.TokenResolver;
 import com.github.fge.jsonschema.core.exceptions.JsonReferenceException;
 import com.github.fge.jsonschema.core.ref.JsonRef;
 import com.github.fge.jsonschema.core.tree.key.SchemaKey;
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
 import javax.annotation.Nonnull;
@@ -216,8 +215,8 @@ public abstract class BaseSchemaTree
     {
         final ObjectNode ret = FACTORY.objectNode();
 
-        ret.put("loadingURI", FACTORY.textNode(key.getLoadingRef().toString()));
-        ret.put("pointer", FACTORY.textNode(pointer.toString()));
+        ret.set("loadingURI", FACTORY.textNode(key.getLoadingRef().toString()));
+        ret.set("pointer", FACTORY.textNode(pointer.toString()));
 
         return ret;
     }
@@ -248,7 +247,7 @@ public abstract class BaseSchemaTree
             return false;
         if (this == obj)
             return true;
-        if (getClass() != obj.getClass())
+        if (!(obj instanceof BaseSchemaTree))
             return false;
         final BaseSchemaTree other = (BaseSchemaTree) obj;
         return key.equals(other.key) && pointer.equals(other.pointer);

--- a/src/main/java/com/github/fge/jsonschema/core/util/URIUtils.java
+++ b/src/main/java/com/github/fge/jsonschema/core/util/URIUtils.java
@@ -19,17 +19,14 @@
 
 package com.github.fge.jsonschema.core.util;
 
-import com.github.fge.jsonschema.core.messages.JsonSchemaCoreMessageBundle;
 import com.github.fge.jsonschema.core.ref.JsonRef;
-import com.github.fge.msgsimple.bundle.MessageBundle;
-import com.github.fge.msgsimple.load.MessageBundles;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 
-import javax.annotation.Nullable;
 import java.net.URI;
 import java.net.URISyntaxException;
+import javax.annotation.Nullable;
 
 /**
  * Utility class for URI normalization
@@ -52,9 +49,6 @@ import java.net.URISyntaxException;
  */
 public final class URIUtils
 {
-    private static final MessageBundle BUNDLE
-        = MessageBundles.getBundle(JsonSchemaCoreMessageBundle.class);
-
     /*
      * ASCII letters, and whatever is legal in a URI scheme
      */

--- a/src/test/java/com/github/fge/jsonschema/core/exceptions/ProcessingExceptionTest.java
+++ b/src/test/java/com/github/fge/jsonschema/core/exceptions/ProcessingExceptionTest.java
@@ -58,6 +58,7 @@ public final class ProcessingExceptionTest
             .hasField("exceptionMessage", inner.getMessage());
     }
 
+    @SuppressWarnings("serial")
     private static class Foo
         extends Exception
     {

--- a/src/test/java/com/github/fge/jsonschema/core/keyword/syntax/SyntaxProcessorTest.java
+++ b/src/test/java/com/github/fge/jsonschema/core/keyword/syntax/SyntaxProcessorTest.java
@@ -195,7 +195,7 @@ public final class SyntaxProcessorTest
         final ObjectNode node = FACTORY.objectNode();
         node.put(K1, K1);
         final ObjectNode schema = FACTORY.objectNode();
-        schema.put("foo", node);
+        schema.set("foo", node);
         final SchemaTree tree
             = new CanonicalSchemaTree(SchemaKey.anonymousKey(), schema);
         final ValueHolder<SchemaTree> holder = ValueHolder.hold("schema", tree);

--- a/src/test/java/com/github/fge/jsonschema/core/keyword/syntax/checkers/BasicSyntaxCheckerTest.java
+++ b/src/test/java/com/github/fge/jsonschema/core/keyword/syntax/checkers/BasicSyntaxCheckerTest.java
@@ -71,7 +71,7 @@ public final class BasicSyntaxCheckerTest
         final AbstractSyntaxChecker checker = spy(new DummyChecker());
         final ProcessingReport report = mock(ProcessingReport.class);
         final ObjectNode schema = FACTORY.objectNode();
-        schema.put(KEYWORD, node);
+        schema.set(KEYWORD, node);
         final SchemaTree tree
             = new CanonicalSchemaTree(SchemaKey.anonymousKey(), schema);
 
@@ -92,7 +92,7 @@ public final class BasicSyntaxCheckerTest
     {
         final NodeType type = NodeType.getNodeType(node);
         final ObjectNode schema = FACTORY.objectNode();
-        schema.put(KEYWORD, node);
+        schema.set(KEYWORD, node);
         final SchemaTree tree
             = new CanonicalSchemaTree(SchemaKey.anonymousKey(), schema);
 

--- a/src/test/java/com/github/fge/jsonschema/core/keyword/syntax/checkers/SyntaxCheckersTest.java
+++ b/src/test/java/com/github/fge/jsonschema/core/keyword/syntax/checkers/SyntaxCheckersTest.java
@@ -286,7 +286,7 @@ public abstract class SyntaxCheckersTest
         final JsonNode node)
     {
         final ObjectNode schema = JacksonUtils.nodeFactory().objectNode();
-        schema.put(keyword, node);
+        schema.set(keyword, node);
         return new CanonicalSchemaTree(SchemaKey.anonymousKey(), schema);
     }
 

--- a/src/test/java/com/github/fge/jsonschema/core/load/SchemaLoaderTest.java
+++ b/src/test/java/com/github/fge/jsonschema/core/load/SchemaLoaderTest.java
@@ -19,6 +19,8 @@
 
 package com.github.fge.jsonschema.core.load;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.github.fge.jackson.JacksonUtils;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
 import com.github.fge.jsonschema.core.load.configuration.LoadingConfiguration;
@@ -48,7 +50,7 @@ public final class SchemaLoaderTest
         = MessageBundles.getBundle(JsonSchemaCoreMessageBundle.class);
 
     private static final byte[] BYTES = JacksonUtils.nodeFactory().objectNode()
-        .toString().getBytes();
+        .toString().getBytes(UTF_8);
 
     @Test
     public void namespacesAreRespected()

--- a/src/test/java/com/github/fge/jsonschema/core/load/URIManagerTest.java
+++ b/src/test/java/com/github/fge/jsonschema/core/load/URIManagerTest.java
@@ -19,6 +19,8 @@
 
 package com.github.fge.jsonschema.core.load;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.fge.jackson.JsonNumEquals;
@@ -102,7 +104,7 @@ public final class URIManagerTest
     {
         final URI uri = URI.create("foo://bar");
         final InputStream sampleStream
-            = new ByteArrayInputStream("}".getBytes());
+            = new ByteArrayInputStream("}".getBytes(UTF_8));
 
         when(mock.fetch(any(URI.class))).thenReturn(sampleStream);
 

--- a/src/test/java/com/github/fge/jsonschema/core/processing/CachingProcessorTest.java
+++ b/src/test/java/com/github/fge/jsonschema/core/processing/CachingProcessorTest.java
@@ -139,6 +139,7 @@ public final class CachingProcessorTest
         }
     }
 
+    @SuppressWarnings("serial")
     private static final class Foo
         extends ProcessingException
     {

--- a/src/test/java/com/github/fge/jsonschema/core/report/ProcessingMessageTest.java
+++ b/src/test/java/com/github/fge/jsonschema/core/report/ProcessingMessageTest.java
@@ -262,6 +262,7 @@ public final class ProcessingMessageTest
         assertEquals(message.getMessage(), "message2: bar");
     }
 
+    @SuppressWarnings("serial")
     private static final class Foo
         extends ProcessingException
     {

--- a/src/test/java/com/github/fge/jsonschema/core/tree/JsonTreeTest.java
+++ b/src/test/java/com/github/fge/jsonschema/core/tree/JsonTreeTest.java
@@ -42,7 +42,7 @@ public final class JsonTreeTest
         childObject.put("a", "b");
 
         final ObjectNode rootNode = factory.objectNode();
-        rootNode.put("object", childObject);
+        rootNode.set("object", childObject);
         testNode = rootNode;
     }
 

--- a/src/test/java/com/github/fge/jsonschema/core/tree/SchemaTreeTest.java
+++ b/src/test/java/com/github/fge/jsonschema/core/tree/SchemaTreeTest.java
@@ -112,7 +112,7 @@ public final class SchemaTreeTest
     {
         final JsonNode node = data.get("lookups");
 
-        final Set<Object[]> set = Sets.newHashSet();
+        final Set<Object[]> set = Sets.newIdentityHashSet();
 
         for (final JsonNode element: node)
             set.add(new Object[] {
@@ -186,7 +186,7 @@ public final class SchemaTreeTest
     public void nonTextualDollarSchemasYieldAnEmptyRef(final JsonNode node)
     {
         final ObjectNode testNode = FACTORY.objectNode();
-        testNode.put("$schema", node);
+        testNode.set("$schema", node);
 
         final SchemaTree tree
             = new CanonicalSchemaTree(SchemaKey.anonymousKey(), testNode);
@@ -207,7 +207,7 @@ public final class SchemaTreeTest
     public void nonAbsoluteDollarSchemasYieldAnEmptyRef(final String s)
     {
         final ObjectNode testNode = FACTORY.objectNode();
-        testNode.put("$schema", FACTORY.textNode(s));
+        testNode.set("$schema", FACTORY.textNode(s));
 
         final SchemaTree tree
             = new CanonicalSchemaTree(SchemaKey.anonymousKey(), testNode);
@@ -231,7 +231,7 @@ public final class SchemaTreeTest
     {
         final JsonRef ref = JsonRef.fromString(s);
         final ObjectNode testNode = FACTORY.objectNode();
-        testNode.put("$schema", FACTORY.textNode(s));
+        testNode.set("$schema", FACTORY.textNode(s));
 
         final SchemaTree tree
             = new CanonicalSchemaTree(SchemaKey.anonymousKey(), testNode);

--- a/src/test/java/com/github/fge/jsonschema/core/util/RegexECMA262HelperTest.java
+++ b/src/test/java/com/github/fge/jsonschema/core/util/RegexECMA262HelperTest.java
@@ -45,6 +45,7 @@ public final class RegexECMA262HelperTest
         invocationCount = 10,
         threadPoolSize = 4
     )
+    @SuppressWarnings("deprecation")
     public void regexesAreCorrectlyAnalyzed(final String regex,
         final boolean valid)
     {
@@ -70,6 +71,7 @@ public final class RegexECMA262HelperTest
         invocationCount = 10,
         threadPoolSize = 4
     )
+    @SuppressWarnings("deprecation")
     public void regexMatchingIsDoneCorrectly(final String regex,
         final String input, final boolean valid)
     {


### PR DESCRIPTION
* Removed unused headers, unused objects.
* Fixed deprecated ObjectNode.put, .putAll to use .set, .setAll.
* Added serialVersionUID as calculated by serialver to several exceptions.
* Fixed a variety of ErrorProne findings: EqualsGetClass, ArrayAsKeyOfSetOrMap, MutableConstantField, VisibleForTestingMisused.
* Suppressed some deprecated warnings on the tests for said deprecated features.
* Suppressed an immutability warnings since Jackson databind doesn't include the immutable attribute on `JsonNode`.