### PR TITLE
Use https for JDK javadoc links.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,15 +71,24 @@ dependencies {
     testCompile(group: "org.assertj", name: "assertj-core", version: "2.9.1");
 }
 
-javadoc.options.links("http://docs.oracle.com/javase/7/docs/api/");
-javadoc.options.links("https://www.javadoc.io/doc/com.google.code.findbugs/jsr305/3.0.1/");
-javadoc.options.links("https://fasterxml.github.io/jackson-databind/javadoc/2.2.0/");
-javadoc.options.links("https://fasterxml.github.io/jackson-core/javadoc/2.2.0/");
-javadoc.options.links("https://www.javadoc.io/doc/com.google.guava/guava/25.1-android/");
-javadoc.options.links("https://java-json-tools.github.io/btf/");
-javadoc.options.links("https://java-json-tools.github.io/msg-simple/");
-javadoc.options.links("https://java-json-tools.github.io/jackson-coreutils/");
-javadoc.options.links("https://java-json-tools.github.io/uri-template/");
+javadoc {
+    options {
+        def currentJavaVersion = org.gradle.api.JavaVersion.current()
+        // FIXME: https://github.com/gradle/gradle/issues/11182
+        if (currentJavaVersion.compareTo(org.gradle.api.JavaVersion.VERSION_1_9) >= 0) {
+            addStringOption("-release", "7");
+        }
+        links("https://docs.oracle.com/javase/7/docs/api/");
+        links("https://www.javadoc.io/doc/com.google.code.findbugs/jsr305/3.0.1/");
+        links("https://fasterxml.github.io/jackson-databind/javadoc/2.2.0/");
+        links("https://fasterxml.github.io/jackson-core/javadoc/2.2.0/");
+        links("https://www.javadoc.io/doc/com.google.guava/guava/25.1-android/");
+        links("https://java-json-tools.github.io/btf/");
+        links("https://java-json-tools.github.io/msg-simple/");
+        links("https://java-json-tools.github.io/jackson-coreutils/");
+        links("https://java-json-tools.github.io/uri-template/");
+    }
+}
 
 /*
  * Necessary! Otherwise TestNG will not be used...


### PR DESCRIPTION
Conditionally adds a `--release=7` flag to tell javadoc the source compatibility. This inhibits javadoc in later JDKs erroring out expecting modules when there are none.

See java-json-tools/btf/issues/7.