### PR TITLE
Allow redirects to schemas with jar:file: URI

### DIFF
--- a/src/main/java/com/github/fge/jsonschema/core/util/URIUtils.java
+++ b/src/main/java/com/github/fge/jsonschema/core/util/URIUtils.java
@@ -188,7 +188,7 @@ public final class URIUtils
             final JsonRef ref = JsonRef.fromURI(argument);
             BUNDLE.checkArgumentPrintf(ref.isAbsolute(),
                 "uriChecks.notAbsoluteRef", argument);
-            BUNDLE.checkArgumentPrintf(!argument.getPath().endsWith("/"),
+            BUNDLE.checkArgumentPrintf(argument.getPath() == null || !argument.getPath().endsWith("/"),
                 "uriChecks.endingSlash", argument);
         }
     };

--- a/src/test/java/com/github/fge/jsonschema/core/util/URIUtilsTest.java
+++ b/src/test/java/com/github/fge/jsonschema/core/util/URIUtilsTest.java
@@ -180,6 +180,31 @@ public final class URIUtilsTest
     }
 
     @DataProvider
+    public Iterator<Object[]> validSchemaURIs()
+    {
+        final List<Object[]> list = Lists.newArrayList();
+
+        String uri;
+
+        uri = "http://example.com/schema";
+        list.add(new Object[] { uri });
+
+        uri = "file:/path/to/schema.json";
+        list.add(new Object[] { uri });
+
+        uri = "jar:file:/path/to/container.jar!/internal/path/to/schema.json";
+        list.add(new Object[] { uri });
+
+        return list.iterator();
+    }
+
+    @Test(dataProvider = "validSchemaURIs")
+    public void validSchemaURIsAreAccepted(final String uri)
+    {
+        URIUtils.checkSchemaURI(URI.create(uri));
+    }
+
+    @DataProvider
     public Iterator<Object[]> invalidSchemaURIs()
     {
         final List<Object[]> list = Lists.newArrayList();


### PR DESCRIPTION
- Avoid `NullPointerException` when jar:file: URIs are provided as redirection target (since `URI.getPath()` oddly returns `null` for this scheme)

Closes #48, #51