### PR TITLE
Update jackson-coreutils deps.

### DIFF
--- a/project.gradle
+++ b/project.gradle
@@ -35,7 +35,8 @@ project.ext {
 dependencies {
     compile(group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.11.0");
     compile(group: "com.google.guava", name: "guava", version: "28.2-android");
-    compile(group: "com.github.java-json-tools", name: "jackson-coreutils", version: "1.12");
+    compile(group: "com.github.java-json-tools", name: "jackson-coreutils", version: "2.0-SNAPSHOT");
+    compile(group: "com.github.java-json-tools", name: "jackson-coreutils-equivalence", version: "1.0-SNAPSHOT");
     compile(group: "com.github.java-json-tools", name: "uri-template", version: "0.10");
     // FIXME: no javadoc
     // FIXME: update beyond 1.7.7.x once we're Java 8 or better.

--- a/src/main/java/com/github/fge/jsonschema/core/keyword/syntax/checkers/common/EnumSyntaxChecker.java
+++ b/src/main/java/com/github/fge/jsonschema/core/keyword/syntax/checkers/common/EnumSyntaxChecker.java
@@ -20,7 +20,7 @@
 package com.github.fge.jsonschema.core.keyword.syntax.checkers.common;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.github.fge.jackson.JsonNumEquals;
+import com.github.fge.jackson.JsonNumEquivalence;
 import com.github.fge.jackson.NodeType;
 import com.github.fge.jackson.jsonpointer.JsonPointer;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
@@ -38,13 +38,12 @@ import java.util.Set;
 /**
  * Syntax checker for the {@code enum} keyword
  *
- * @see JsonNumEquals
+ * @see JsonNumEquivalence
  */
 public final class EnumSyntaxChecker
     extends AbstractSyntaxChecker
 {
-    private static final Equivalence<JsonNode> EQUIVALENCE
-        = JsonNumEquals.getInstance();
+    private static final Equivalence<JsonNode> EQUIVALENCE = JsonNumEquivalence.getInstance();
 
     private static final SyntaxChecker INSTANCE = new EnumSyntaxChecker();
 

--- a/src/main/java/com/github/fge/jsonschema/core/keyword/syntax/checkers/draftv3/DraftV3TypeKeywordSyntaxChecker.java
+++ b/src/main/java/com/github/fge/jsonschema/core/keyword/syntax/checkers/draftv3/DraftV3TypeKeywordSyntaxChecker.java
@@ -20,7 +20,7 @@
 package com.github.fge.jsonschema.core.keyword.syntax.checkers.draftv3;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.github.fge.jackson.JsonNumEquals;
+import com.github.fge.jackson.JsonNumEquivalence;
 import com.github.fge.jackson.NodeType;
 import com.github.fge.jackson.jsonpointer.JsonPointer;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
@@ -46,7 +46,7 @@ public final class DraftV3TypeKeywordSyntaxChecker
 {
     private static final String ANY = "any";
     private static final Equivalence<JsonNode> EQUIVALENCE
-        = JsonNumEquals.getInstance();
+        = JsonNumEquivalence.getInstance();
 
     public DraftV3TypeKeywordSyntaxChecker(final String keyword)
     {

--- a/src/main/java/com/github/fge/jsonschema/core/keyword/syntax/checkers/draftv4/DraftV4TypeSyntaxChecker.java
+++ b/src/main/java/com/github/fge/jsonschema/core/keyword/syntax/checkers/draftv4/DraftV4TypeSyntaxChecker.java
@@ -20,7 +20,7 @@
 package com.github.fge.jsonschema.core.keyword.syntax.checkers.draftv4;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.github.fge.jackson.JsonNumEquals;
+import com.github.fge.jackson.JsonNumEquivalence;
 import com.github.fge.jackson.NodeType;
 import com.github.fge.jackson.jsonpointer.JsonPointer;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
@@ -45,8 +45,7 @@ public final class DraftV4TypeSyntaxChecker
     private static final EnumSet<NodeType> ALL_TYPES
         = EnumSet.allOf(NodeType.class);
 
-    private static final Equivalence<JsonNode> EQUIVALENCE
-        = JsonNumEquals.getInstance();
+    private static final Equivalence<JsonNode> EQUIVALENCE = JsonNumEquivalence.getInstance();
 
     private static final SyntaxChecker INSTANCE
         = new DraftV4TypeSyntaxChecker();

--- a/src/main/java/com/github/fge/jsonschema/core/keyword/syntax/checkers/draftv4/RequiredSyntaxChecker.java
+++ b/src/main/java/com/github/fge/jsonschema/core/keyword/syntax/checkers/draftv4/RequiredSyntaxChecker.java
@@ -20,7 +20,7 @@
 package com.github.fge.jsonschema.core.keyword.syntax.checkers.draftv4;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.github.fge.jackson.JsonNumEquals;
+import com.github.fge.jackson.JsonNumEquivalence;
 import com.github.fge.jackson.NodeType;
 import com.github.fge.jackson.jsonpointer.JsonPointer;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
@@ -42,8 +42,7 @@ import java.util.Set;
 public final class RequiredSyntaxChecker
     extends AbstractSyntaxChecker
 {
-    private static final Equivalence<JsonNode> EQUIVALENCE
-        = JsonNumEquals.getInstance();
+    private static final Equivalence<JsonNode> EQUIVALENCE = new JsonNumEquivalence();
 
     private static final SyntaxChecker INSTANCE = new RequiredSyntaxChecker();
 

--- a/src/main/java/com/github/fge/jsonschema/core/keyword/syntax/checkers/helpers/DependenciesSyntaxChecker.java
+++ b/src/main/java/com/github/fge/jsonschema/core/keyword/syntax/checkers/helpers/DependenciesSyntaxChecker.java
@@ -21,7 +21,7 @@ package com.github.fge.jsonschema.core.keyword.syntax.checkers.helpers;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.fge.jackson.JacksonUtils;
-import com.github.fge.jackson.JsonNumEquals;
+import com.github.fge.jackson.JsonNumEquivalence;
 import com.github.fge.jackson.NodeType;
 import com.github.fge.jackson.jsonpointer.JsonPointer;
 import com.github.fge.jsonschema.core.exceptions.InvalidSchemaException;
@@ -49,8 +49,7 @@ public abstract class DependenciesSyntaxChecker
     /**
      * JSON Schema equivalence
      */
-    protected static final Equivalence<JsonNode> EQUIVALENCE
-        = JsonNumEquals.getInstance();
+    protected static final Equivalence<JsonNode> EQUIVALENCE = JsonNumEquivalence.getInstance();
 
     /**
      * Valid types for one dependency value


### PR DESCRIPTION
The de-Guava-ing of jackson-coreutils means pulling in the Guava-specific Equivalence class from the new jackson-coreutils-equivalence.