### PR TITLE
Add support for GraalJS script engine on RegExp checks

### DIFF
--- a/src/test/java/com/github/fge/jsonschema/core/util/RegexECMA262HelperTest.java
+++ b/src/test/java/com/github/fge/jsonschema/core/util/RegexECMA262HelperTest.java
@@ -71,7 +71,7 @@ public final class RegexECMA262HelperTest
     {
         return ImmutableList.of(
             new Object[] { "[^]", true },
-            new Object[] { "(?<=foo)bar", false },
+            new Object[] { "(?<=foobar", false },
             new Object[] { "", true },
             new Object[] { "[a-z]+(?!foo)(?=bar)", true }
         ).iterator();


### PR DESCRIPTION
The addition of GraalJS has another advantage.

With ECMAScript 2018 more RegExp features have been added. Nashorn and Rhino do not support these changes but GraalJS does.

* Named Capture Groups
* Unicode Property Escapes
* Lookbehind Assertions
* (dotAll) Flag


I haven't add unit tests. The GraalJS dependency is 20MB big and recommends JDK 11. So I just tested it locally.