### PR TITLE
Clarify "dual-licensed"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -6,6 +6,7 @@ This software is dual-licensed under:
 
 The text of both licenses is included (under the names LGPL-3.0.txt and
 ASL-2.0.txt respectively).
+Should you choose to redistribute, you can pick either, or continue to dual license.
 
 Direct link to the sources:
 


### PR DESCRIPTION
Per https://github.com/java-json-tools/json-schema-validator/pull/351 - I assume the same clarification would apply to this repository. Here's a PR to bring it over.