### PR TITLE
Migrate off deprecated API

### DIFF
--- a/src/test/java/com/github/fge/jsonschema/core/processing/ProcessorSelectorTest.java
+++ b/src/test/java/com/github/fge/jsonschema/core/processing/ProcessorSelectorTest.java
@@ -154,10 +154,10 @@ public final class ProcessorSelectorTest
         processor.process(report, input);
 
         verify(processor1, onlyOnce()).process(same(report), same(input));
-        verifyZeroInteractions(processor2, byDefault);
+        verifyNoMoreInteractions(processor2, byDefault);
 
         for (final Processor<In, Out> p: otherProcessors)
-            verifyZeroInteractions(p);
+            verifyNoMoreInteractions(p);
     }
 
     @Test
@@ -173,9 +173,9 @@ public final class ProcessorSelectorTest
         processor.process(report, input);
 
         verify(processor2, onlyOnce()).process(same(report), same(input));
-        verifyZeroInteractions(processor1, byDefault);
+        verifyNoMoreInteractions(processor1, byDefault);
         for (final Processor<In, Out> p: otherProcessors)
-            verifyZeroInteractions(p);
+            verifyNoMoreInteractions(p);
     }
 
     @Test
@@ -190,9 +190,9 @@ public final class ProcessorSelectorTest
             processor.process(report, input);
             fail("No exception thrown!!");
         } catch (ProcessingException e) {
-            verifyZeroInteractions(processor1, processor2);
+            verifyNoMoreInteractions(processor1, processor2);
             for (final Processor<In, Out> p: otherProcessors)
-                verifyZeroInteractions(p);
+                verifyNoMoreInteractions(p);
             assertMessage(e.getProcessingMessage())
                 .hasMessage(BUNDLE.getMessage("processing.noProcessor"));
         }
@@ -210,11 +210,11 @@ public final class ProcessorSelectorTest
 
         processor.process(report, input);
 
-        verifyZeroInteractions(processor1, processor2);
+        verifyNoMoreInteractions(processor1, processor2);
         verify(byDefault, onlyOnce()).process(report, input);
 
         for (final Processor<In, Out> p: otherProcessors)
-            verifyZeroInteractions(p);
+            verifyNoMoreInteractions(p);
     }
 
     private interface In extends MessageProvider


### PR DESCRIPTION
`org.mockito.Mockito#verifyZeroInteractions` is a deprecated alias of
`verifyNoMoreInteractions`, which is being removed in the next version
of Mockito:
https://github.com/mockito/mockito/commit/caf35b24e2764df0498469526ecb3e7ec68a0430